### PR TITLE
Squashing your commits

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -9,6 +9,32 @@ const listSelector = 'div[role="navigation"] > div > ul';
 const conversationSelector = '._4u-c._1wfr > ._5f0v.uiScrollableArea';
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
 
+function showSettingsMenu() {
+	document.querySelector('._30yy._2fug._p').click();
+}
+
+function selectMenuItem(itemNumber) {
+	const selector = document.querySelector(`._54nq._2i-c._558b._2n_z li:nth-child(${itemNumber}) a`);
+	selector.click();
+}
+
+function selectOtherListViews(itemNumber) {
+	// In case one of other views is shown
+	clickBackButton();
+
+	// Create the menu for the below
+	showSettingsMenu();
+
+	selectMenuItem(itemNumber);
+}
+
+function clickBackButton() {
+	const backButton = document.querySelector('._30yy._2oc9');
+	if (backButton) {
+		backButton.click();
+	}
+}
+
 ipc.on('show-preferences', async () => {
 	if (isPreferencesOpen()) {
 		return;
@@ -103,6 +129,22 @@ ipc.on('toggle-mute-notifications', async (event, defaultStatus) => {
 ipc.on('toggle-message-buttons', async () => {
 	const messageButtons = await elementReady('._39bj');
 	messageButtons.style.display = config.get('showMessageButtons') ? 'flex' : 'none';
+});
+
+ipc.on('show-active-contacts-view', () => {
+	selectOtherListViews(3);
+});
+
+ipc.on('show-message-requests-view', () => {
+	selectOtherListViews(4);
+});
+
+ipc.on('show-archived-threads-view', () => {
+	selectOtherListViews(5);
+});
+
+ipc.on('toggle-unread-threads-view', () => {
+	selectOtherListViews(6);
 });
 
 function setDarkMode() {
@@ -326,6 +368,38 @@ function initTouchBar() {
 		attributes: true,
 		attributeFilter: ['class']
 	});
+}
+
+function openActiveContactsView() {
+	// Create the menu for the below
+	document.querySelector('._30yy._2fug._p').click();
+
+	const nodes = document.querySelectorAll('._54nq._2i-c._558b._2n_z li:nth-child(3) a');
+	nodes[nodes.length - 1].click();
+}
+
+function openMessageRequestsView() {
+	// Create the menu for the below
+	document.querySelector('._30yy._2fug._p').click();
+
+	const nodes = document.querySelectorAll('._54nq._2i-c._558b._2n_z li:nth-child(4) a');
+	nodes[nodes.length - 1].click();
+}
+
+function openArchivedThreadsView() {
+	// Create the menu for the below
+	document.querySelector('._30yy._2fug._p').click();
+
+	const nodes = document.querySelectorAll('._54nq._2i-c._558b._2n_z li:nth-child(5) a');
+	nodes[nodes.length - 1].click();
+}
+
+function toggleUnreadThreadsView() {
+	// Create the menu for the below
+	document.querySelector('._30yy._2fug._p').click();
+
+	const nodes = document.querySelectorAll('._54nq._2i-c._558b._2n_z li:nth-child(6) a');
+	nodes[nodes.length - 1].click();
 }
 
 // Inject a global style node to maintain custom appearance after conversation change or startup

--- a/menu.js
+++ b/menu.js
@@ -31,10 +31,8 @@ const viewSubmenu = [
 		}
 	},
 	{
-		type: 'separator'
-	},
-	{
 		label: 'Toggle Sidebar',
+		position: 'endof=toggle',
 		accelerator: 'CmdOrCtrl+Shift+S',
 		click() {
 			sendAction('toggle-sidebar');
@@ -51,9 +49,37 @@ const viewSubmenu = [
 	},
 	{
 		label: 'Toggle Dark Mode',
+		position: 'endof=toggle',
 		accelerator: 'CmdOrCtrl+D',
 		click() {
 			sendAction('toggle-dark-mode');
+		}
+	},
+	{
+		type: 'separator'
+	},
+	{
+		label: 'Show Active Contacts',
+		click() {
+			sendAction('show-active-contacts-view');
+		}
+	},
+	{
+		label: 'Show Message Requests',
+		click() {
+			sendAction('show-message-requests-view');
+		}
+	},
+	{
+		label: 'Show Archived Threads',
+		click() {
+			sendAction('show-archived-threads-view');
+		}
+	},
+	{
+		label: 'Toggle Unread Threads',
+		click() {
+			sendAction('toggle-unread-threads-view');
 		}
 	}
 ];
@@ -98,6 +124,7 @@ ${process.platform} ${process.arch} ${os.release()}`;
 if (process.platform === 'darwin') {
 	viewSubmenu.push({
 		label: 'Toggle Vibrancy',
+		position: 'endof=toggle',
 		click() {
 			sendAction('toggle-vibrancy');
 		}


### PR DESCRIPTION
Moved 'Toggle vibracy' next to other toggle items
This will be using splice as insert function so it will insert 'Toggle
vibracy' menu item if it's on darwin, not append it to the end of
submenu.
Moved duplicate code to one method
In my opinion there should be a separate event for every menu item but
I've added a method that clicks on document elements because every one
of these items have very similar code in event listeners.
Make XO happy
Added all requested changes
Turned one line if statement to regular if statement and added separator
for macOS.
Added some requested changes
Added requested change for making an external function for querying so
it would be reusable, moving logic to event handler from separate
functions and changes some labels in menu.
Added messenger menu options to view
I've added options from messenger settings menu to view menu as
suggested.

Closes: https://github.com/sindresorhus/caprine/issues/352